### PR TITLE
Pagination for gif index page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'haml-rails'
 gem 'simple_form'
 gem 'jquery-rails'
 gem 'rails_tokeninput'
+gem 'will_paginate'
 
 gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    will_paginate (3.0.3)
 
 PLATFORMS
   ruby
@@ -144,3 +145,4 @@ DEPENDENCIES
   simple_form
   uglifier (>= 1.0.3)
   unicorn
+  will_paginate

--- a/app/controllers/gifs_controller.rb
+++ b/app/controllers/gifs_controller.rb
@@ -3,7 +3,7 @@ class GifsController < ApplicationController
   respond_to :html, :json
 
   def index
-    respond_with @gifs = Gif.all
+    respond_with @gifs = Gif.paginate(:page => params[:page], :per_page => 20)
   end
 
   def show

--- a/app/views/gifs/index.html.haml
+++ b/app/views/gifs/index.html.haml
@@ -4,6 +4,8 @@
   = f.input :tag_tokens, label: "Keywords" #, input_html: { data: {load: Tag.all} }
   = f.submit
 
+= will_paginate @gifs
+
 - unless @gifs.empty?
   %ul#gif-list
     - @gifs.reverse_each do |gif|


### PR DESCRIPTION
First of all, thanks for this wonderful website!! Me and my friends have been farming gifs for a couple of weeks and we always thought about an easier way to share them instead of sending a jabber message to each one of us. And then we finally found gifhub :-)

Over the post few weeks we have been filling gifhub. In its current state gifhub brings some browsers at its limit or even crashes them because of the mass amount of gifs displayed simultaneously. So I though it would be wise to have some paging functionality.

I implemented paging in the most simple way possible. I skipped the test because I saw that you didn't really test it either. If you'd like to have tests for this, please feel free ask me again.
