### PR TITLE
order got messed up

### DIFF
--- a/app/controllers/gifs_controller.rb
+++ b/app/controllers/gifs_controller.rb
@@ -3,7 +3,7 @@ class GifsController < ApplicationController
   respond_to :html, :json
 
   def index
-    respond_with @gifs = Gif.paginate(:page => params[:page], :per_page => 20)
+    respond_with @gifs = Gif.order('created_at ASC').paginate(:page => params[:page], :per_page => 20)
   end
 
   def show


### PR DESCRIPTION
With my latest commit the ordering got messed up although I don't quite understand why. To make sure that the newest gifs are on the first page I added a fixed ordering using the `created_at` timestamp. Sorry about the inconvenience.
